### PR TITLE
Guardian can send messages and manage queue between swarm and guardian

### DIFF
--- a/lib-core/src/main/java/org/rfcx/guardian/utility/misc/DbUtils.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/misc/DbUtils.java
@@ -126,6 +126,19 @@ public class DbUtils {
 			closeDb();
 		}
 	}
+
+	public void updateRowByColumn(String table, String updateColumn, String updateValue, String pointColumn, String pointValue) {
+		SQLiteDatabase db = openDb();
+		try {
+			ContentValues cv = new ContentValues();
+			cv.put(updateColumn, updateValue);
+			db.update(table, cv, pointColumn + "=" + pointValue, null);
+		} catch (Exception e) {
+			RfcxLog.logExc(logTag, e);
+		} finally {
+			closeDb();
+		}
+	}
 	
 	public static List<String[]> getRows(SQLiteDatabase db, String tableName, String[] tableColumns, String selection, String[] selectionArgs, String orderBy, int rowOffset, int rowLimit) {
 		

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmDispatchService.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmDispatchService.java
@@ -7,6 +7,7 @@ import android.util.Log;
 
 import org.rfcx.guardian.admin.RfcxGuardian;
 import org.rfcx.guardian.admin.comms.swm.data.SwmTDResponse;
+import org.rfcx.guardian.admin.comms.swm.data.SwmUnsentMsg;
 import org.rfcx.guardian.utility.misc.DateTimeUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxComm;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
@@ -101,7 +102,11 @@ public class SwmDispatchService extends Service {
 								if (!app.swmUtils.isInFlight) {
 									app.swmUtils.isInFlight = true;
 									app.rfcxSvc.triggerService(SwmDispatchTimeoutService.SERVICE_NAME, true);
-									String swmMessageId = app.swmUtils.getApi().transmitData("\"" + msgBody + "\""); // TODO unit test
+									// update queue between Guardian and Swarm
+									app.swmUtils.updateQueueMessagesFromSwarm(app.swmUtils.getApi().getUnsentMessages());
+
+									// send message
+									String swmMessageId = app.swmUtils.getApi().transmitData("\"" + msgBody + "\"");
 									if (swmMessageId != null) {
 										app.rfcxSvc.reportAsActive(SERVICE_NAME);
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmDispatchService.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmDispatchService.java
@@ -98,6 +98,7 @@ public class SwmDispatchService extends Service {
 
 								String msgId = swmForDispatch[4];
 								String msgBody = swmForDispatch[3];
+								String msgSwmMsgId = swmForDispatch[5];
 
 								if (!app.swmUtils.isInFlight) {
 									app.swmUtils.isInFlight = true;
@@ -108,7 +109,7 @@ public class SwmDispatchService extends Service {
 
 									// getting unsent message count from Swarm
 									int unsentMessageNumbers = app.swmUtils.getApi().getNumberOfUnsentMessages();
-									if (unsentMessageNumbers <= 50) {
+									if (unsentMessageNumbers <= 50 && msgSwmMsgId == null) {
 
 										// send message
 										String swmMessageId = app.swmUtils.getApi().transmitData("\"" + msgBody + "\"");

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmDispatchService.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmDispatchService.java
@@ -101,12 +101,12 @@ public class SwmDispatchService extends Service {
 								if (!app.swmUtils.isInFlight) {
 									app.swmUtils.isInFlight = true;
 									app.rfcxSvc.triggerService(SwmDispatchTimeoutService.SERVICE_NAME, true);
-									SwmTDResponse tdResponse = null; //app.swmUtils.getApi().transmitData("\"" + msgBody + "\""); // TODO unit test
-									if (tdResponse != null) {
+									String swmMessageId = app.swmUtils.getApi().transmitData("\"" + msgBody + "\""); // TODO unit test
+									if (swmMessageId != null) {
 										app.rfcxSvc.reportAsActive(SERVICE_NAME);
 
 										app.swmUtils.consecutiveDeliveryFailureCount = 0;
-										app.swmMessageDb.dbSwmQueued.deleteSingleRowByMessageId(msgId);
+										app.swmMessageDb.dbSwmQueued.updateSwmMessageIdByMessageId(msgId, swmMessageId);
 
 										String concatSegId = msgBody.substring(0, 4) + "-" + msgBody.substring(4, 7);
 										Log.v(logTag, DateTimeUtils.getDateTime(rightNow) + " - Segment '" + concatSegId + "' sent by SWM (" + msgBody.length() + " chars)");

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -27,8 +27,9 @@ public class SwmMessageDb {
 	static final String C_ADDRESS = "address";
 	static final String C_BODY = "body";
 	static final String C_MESSAGE_ID = "message_id";
+	static final String C_SWM_MESSAGE_ID = "swm_message_id";
 	static final String C_LAST_ACCESSED_AT = "last_accessed_at";
-	private static final String[] ALL_COLUMNS = new String[] { C_CREATED_AT, C_TIMESTAMP, C_ADDRESS, C_BODY, C_MESSAGE_ID, C_LAST_ACCESSED_AT };
+	private static final String[] ALL_COLUMNS = new String[] { C_CREATED_AT, C_TIMESTAMP, C_ADDRESS, C_BODY, C_MESSAGE_ID, C_SWM_MESSAGE_ID, C_LAST_ACCESSED_AT };
 
 	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { }; // "0.6.43"
 	private boolean DROP_TABLE_ON_UPGRADE = false;
@@ -36,13 +37,14 @@ public class SwmMessageDb {
 	private String createColumnString(String tableName) {
 		StringBuilder sbOut = new StringBuilder();
 		sbOut.append("CREATE TABLE ").append(tableName)
-			.append("(").append(C_CREATED_AT).append(" INTEGER")
-			.append(", ").append(C_TIMESTAMP).append(" TEXT")
-			.append(", ").append(C_ADDRESS).append(" TEXT")
-			.append(", ").append(C_BODY).append(" TEXT")
-			.append(", ").append(C_MESSAGE_ID).append(" TEXT")
-			.append(", ").append(C_LAST_ACCESSED_AT).append(" INTEGER")
-			.append(")");
+                .append("(").append(C_CREATED_AT).append(" INTEGER")
+                .append(", ").append(C_TIMESTAMP).append(" TEXT")
+                .append(", ").append(C_ADDRESS).append(" TEXT")
+                .append(", ").append(C_BODY).append(" TEXT")
+                .append(", ").append(C_MESSAGE_ID).append(" TEXT")
+                .append(", ").append(C_SWM_MESSAGE_ID).append(" TEXT")
+                .append(", ").append(C_LAST_ACCESSED_AT).append(" INTEGER")
+                .append(")");
 		return sbOut.toString();
 	}
 
@@ -160,11 +162,20 @@ public class SwmMessageDb {
 		}
 
 		public int deleteSingleRowByMessageId(String message_id) {
-			this.dbUtils.deleteRowsWithinQueryByTimestamp(TABLE, C_MESSAGE_ID, message_id);
+			this.dbUtils.deleteRowsWithinQueryByOneColumn(TABLE, C_MESSAGE_ID, message_id);
 			return 0;
+		}
+
+        public int deleteSingleRowBySwmMessageId(String swmMessageId) {
+            this.dbUtils.deleteRowsWithinQueryByOneColumn(TABLE, C_SWM_MESSAGE_ID, swmMessageId);
+            return 0;
+        }
+
+		public void updateSwmMessageIdByMessageId(String messageId, String swmMessageId) {
+			this.dbUtils.updateRowByColumn(TABLE, C_SWM_MESSAGE_ID, swmMessageId, C_MESSAGE_ID, messageId);
 		}
 
 	}
 	public final DbSwmQueued dbSwmQueued;
-	
+
 }

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -172,7 +172,7 @@ public class SwmMessageDb {
             return 0;
         }
 
-		public void updateSwmMessageIdByMessageId(String messageId, String swmMessageId) {
+        public void updateSwmMessageIdByMessageId(String messageId, String swmMessageId) {
 			this.dbUtils.updateRowByColumn(TABLE, C_SWM_MESSAGE_ID, swmMessageId, C_MESSAGE_ID, messageId);
 		}
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -168,8 +168,8 @@ public class SwmMessageDb {
 		}
 
         public int deleteSingleRowBySwmMessageId(String swmMessageId) {
-            this.dbUtils.deleteRowsWithinQueryByOneColumn(TABLE, C_SWM_MESSAGE_ID, swmMessageId);
-            return 0;
+			this.dbUtils.deleteRowsWithinQueryByOneColumn(TABLE, C_SWM_MESSAGE_ID, swmMessageId);
+			return 0;
         }
 
         public void updateSwmMessageIdByMessageId(String messageId, String swmMessageId) {

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -98,7 +98,7 @@ public class SwmMessageDb {
 			this.dbUtils = new DbUtils(context, DATABASE, TABLE, VERSION, createColumnString(TABLE), DROP_TABLE_ON_UPGRADE);
 		}
 
-		public int insert(long timestamp, String address, String body, String message_id) {
+		public int insert(long timestamp, String address, String body, String message_id, String swmMessageId) {
 
 			ContentValues values = new ContentValues();
 			values.put(C_CREATED_AT, (new Date()).getTime());
@@ -106,6 +106,7 @@ public class SwmMessageDb {
 			values.put(C_ADDRESS, address);
 			values.put(C_BODY, body);
 			values.put(C_MESSAGE_ID, message_id);
+			values.put(C_SWM_MESSAGE_ID, swmMessageId);
 			values.put(C_LAST_ACCESSED_AT, 0);
 
 			return this.dbUtils.insertRow(TABLE, values);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -18,6 +18,7 @@ import org.rfcx.guardian.utility.misc.DateTimeUtils
 
 import android.text.TextUtils
 import org.rfcx.guardian.admin.comms.swm.control.SwmPower
+import org.rfcx.guardian.admin.comms.swm.data.SwmUnsentMsg
 
 import org.rfcx.guardian.utility.rfcx.RfcxPrefs
 
@@ -46,6 +47,23 @@ class SwmUtils(private val context: Context) {
             }
         }
         return true
+    }
+
+    fun updateQueueMessagesFromSwarm(swmUnsentMessages: List<SwmUnsentMsg>?) {
+        val swarmMessageIdQueues = swmUnsentMessages?.map { it.messageId } ?: return
+        val guardianMessageIdQueues = app.swmMessageDb.dbSwmQueued.allRows
+        for (guardianMessage in guardianMessageIdQueues) {
+            if (!swarmMessageIdQueues.contains(guardianMessage[5])) {
+                app.swmMessageDb.dbSwmSent.insert(
+                    guardianMessage[1].toLong(),
+                    guardianMessage[2],
+                    guardianMessage[3],
+                    guardianMessage[4],
+                    guardianMessage[5]
+                )
+                app.swmMessageDb.dbSwmQueued.deleteSingleRowBySwmMessageId(guardianMessage[5])
+            }
+        }
     }
 
     companion object {

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -51,7 +51,8 @@ class SwmUtils(private val context: Context) {
 
     fun updateQueueMessagesFromSwarm(swmUnsentMessages: List<SwmUnsentMsg>?) {
         val swarmMessageIdQueues = swmUnsentMessages?.map { it.messageId } ?: return
-        val guardianMessageIdQueues = app.swmMessageDb.dbSwmQueued.allRows
+        val guardianMessageIdQueues = app.swmMessageDb.dbSwmQueued.allRows.filter { it.getOrNull(5) != null }
+        Log.d(logTag, "Swarm queue: ${swarmMessageIdQueues.size}  Guardian queue: ${guardianMessageIdQueues.size}")
         for (guardianMessage in guardianMessageIdQueues) {
             if (!swarmMessageIdQueues.contains(guardianMessage[5])) {
                 app.swmMessageDb.dbSwmSent.insert(

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
@@ -22,7 +22,7 @@ class SwmApi(private val connection: SwmConnection) {
     }
 
     fun getUnsentMessages(): List<SwmUnsentMsg>? {
-        val results = connection.execute(Command.MT.name, "L=U")
+        val results = connection.execute(Command.MT.name, "L=U", 2)
         val unsentMessages = arrayListOf<SwmUnsentMsg>()
         if (results.isEmpty()) return null
         results.forEach { payload ->

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
@@ -12,29 +12,29 @@ class SwmApi(private val connection: SwmConnection) {
     private val datetimeCompactFormatter = SimpleDateFormat("yyyyMMddHHmmss").also { it.timeZone = TimeZone.getTimeZone("GMT") }
 
     // TODO unit test
-//    fun transmitData(msgStr: String): SwmTDResponse? {
-//        return connection.execute(Command.TD.name, msgStr).firstOrNull()?.let { payload ->
-//            return "\$OK,(-?[0-9]+)".toRegex().find(payload)?.let { result ->
-//                val (id) = result.destructured
-//                Log.d("SwmCommand", "TD= $id")
-//                return SwmTDResponse(messageId = id)
-//            }
-//        }
-//    }
+    fun transmitData(msgStr: String): String? {
+        val results = connection.executeWithoutTimeout(Command.TD.name, msgStr)
+        val regex = "OK,(-?[0-9]+)".toRegex()
+        val firstMatchResult = results.mapNotNull { regex.find(it) }.firstOrNull()
+        return firstMatchResult?.let { match ->
+            val (messageId) = match.destructured
+            return messageId
+        }
+    }
 
     // TODO unit test
-//    fun getUnsentMessages(): SwmMTResponse? {
-//        val unsentMessages = connection.execute(Command.MT.name, "L=U")
-//        val unsentMsgIds = arrayListOf<SwmUnsentMsg>()
-//        if (unsentMessages.isEmpty()) return null
-//        unsentMessages.forEach { payload ->
-//            "OK,(-?[0-9]+)".toRegex().find(payload)?.let { result ->
-//                val (id) = result.destructured
-//                unsentMsgIds.add(SwmUnsentMsg("", id))
-//            }
-//        }
-//        return SwmMTResponse(unsentMsgIds)
-//    }
+    fun getUnsentMessages(): SwmMTResponse? {
+        val unsentMessages = connection.execute(Command.MT.name, "L=U")
+        val unsentMsgIds = arrayListOf<SwmUnsentMsg>()
+        if (unsentMessages.isEmpty()) return null
+        unsentMessages.forEach { payload ->
+            "OK,(-?[0-9]+)".toRegex().find(payload)?.let { result ->
+                val (id) = result.destructured
+                unsentMsgIds.add(SwmUnsentMsg("", id))
+            }
+        }
+        return SwmMTResponse(unsentMsgIds)
+    }
 
     fun getNumberOfUnsentMessages(): Int {
         return connection.execute(Command.MT.name, "C=U", 2).firstOrNull()?.let { payload ->
@@ -45,13 +45,6 @@ class SwmApi(private val connection: SwmConnection) {
             } ?: 0
         } ?: 0
     }
-
-    // TODO unit test
-//    fun sleep(time: Long): Boolean? {
-//        return connection.execute(Command.SL.name, "S=$time").firstOrNull()?.let { payload ->
-//            return payload.contains("OK")
-//        }
-//    }
 
     fun powerOff(): Boolean {
         return connection.execute(Command.PO.name, "").firstOrNull()?.let { payload ->

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmConnection.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmConnection.kt
@@ -9,14 +9,12 @@ class SwmConnection(private val shell: SwmShell) {
     fun execute(command: String, arguments: String, timeout: Int = 1): List<String> {
         val request = makeRequest(command, arguments)
         val responseLines = shell.execute(request, timeout)
-        Log.d("RfcxSwmCommand", "Responses: " + responseLines.joinToString())
         return findMatchingResponses(responseLines, command)
     }
 
     fun executeWithoutTimeout(command: String, arguments: String): List<String> {
         val request = makeRequest(command, arguments)
         val responseLines = shell.execute(request)
-        Log.d("RfcxSwmCommand", "Responses: " + responseLines.joinToString())
         return findMatchingResponses(responseLines, command)
     }
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/data/SwmUnsentMsg.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/data/SwmUnsentMsg.kt
@@ -2,5 +2,6 @@ package org.rfcx.guardian.admin.comms.swm.data
 
 data class SwmUnsentMsg(
     val hex: String,
-    val messageId: String
+    val messageId: String,
+    val timestamp: String
 )

--- a/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiMTTest.kt
+++ b/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiMTTest.kt
@@ -3,6 +3,7 @@ package org.rfcx.guardian.admin.comms.swm
 import org.junit.Test
 import org.rfcx.guardian.admin.comms.swm.api.SwmApi
 import org.rfcx.guardian.admin.comms.swm.api.SwmConnection
+import org.rfcx.guardian.admin.comms.swm.data.SwmUnsentMsg
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -63,5 +64,32 @@ class SwmApiMTTest {
         // Assert
         assertNotNull(unsentCount)
         assertEquals(12, unsentCount)
+    }
+
+    @Test
+    fun canGetAllUnsentMessages() {
+        // Arrange
+        val expectResults = listOf(
+            "\$MT 68692066726f6d20737761726d,4428826476689,1605639598*55",
+            "\$MT 686f6c6120646573646520737761726d,4428826476690,1605639664*53"
+        )
+        val expectOutputs = listOf(
+            SwmUnsentMsg("68692066726f6d20737761726d", "4428826476689", "1605639598"),
+            SwmUnsentMsg("686f6c6120646573646520737761726d", "4428826476690", "1605639664")
+        )
+        val shell = SwmMockShell(expectResults)
+        val api = SwmApi(SwmConnection(shell))
+
+        // Act
+        val unsentMessages = api.getUnsentMessages()
+
+        // Assert
+        assertNotNull(unsentMessages)
+        assertEquals(2, unsentMessages.size)
+        unsentMessages.forEachIndexed { index, unsentMessage ->
+            assertEquals(expectOutputs[index].hex, unsentMessage.hex)
+            assertEquals(expectOutputs[index].messageId, unsentMessage.messageId)
+            assertEquals(expectOutputs[index].timestamp, unsentMessage.timestamp)
+        }
     }
 }

--- a/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiTDTest.kt
+++ b/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiTDTest.kt
@@ -1,0 +1,38 @@
+package org.rfcx.guardian.admin.comms.swm
+
+import org.junit.Test
+import org.rfcx.guardian.admin.comms.swm.api.SwmApi
+import org.rfcx.guardian.admin.comms.swm.api.SwmConnection
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class SwmApiTDTest {
+
+    @Test
+    fun canSendMessage() {
+        // Arrange
+        val shell = SwmMockShell(listOf("\$TD OK,5354468575855*2a"))
+        val api = SwmApi(SwmConnection(shell))
+
+        // Act
+        val messageId = api.transmitData("") // no need to add any message here since we mocked Shell class
+
+        // Assert
+        assertNotNull(messageId)
+        assertEquals("5354468575855", messageId)
+    }
+
+    @Test
+    fun canSendMessageButError() {
+        // Arrange
+        val shell = SwmMockShell(listOf("\$TD ERR,BADDATA*0e"))
+        val api = SwmApi(SwmConnection(shell))
+
+        // Act
+        val messageId = api.transmitData("") // no need to add any message here since we mocked Shell class
+
+        // Assert
+        assertNull(messageId)
+    }
+}

--- a/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiTDTest.kt
+++ b/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiTDTest.kt
@@ -24,6 +24,20 @@ class SwmApiTDTest {
     }
 
     @Test
+    fun canSendMessageWithMultipleOutput() {
+        // Arrange
+        val shell = SwmMockShell(listOf("\$TD OK,5354468575855*2a", "\$MT SOMETHING*2a"))
+        val api = SwmApi(SwmConnection(shell))
+
+        // Act
+        val messageId = api.transmitData("") // no need to add any message here since we mocked Shell class
+
+        // Assert
+        assertNotNull(messageId)
+        assertEquals("5354468575855", messageId)
+    }
+
+    @Test
     fun canSendMessageButError() {
         // Arrange
         val shell = SwmMockShell(listOf("\$TD ERR,BADDATA*0e"))


### PR DESCRIPTION
## Summary

- resolve #89 
- Add command for sending message `TD`
- Add command for getting all unsent messages `MT L=U`
- Manage queue every time `SwmDispatchService` is triggered
- Cap the limit to `50` on Swarm unsent messages to not queue up too much