### PR TITLE
Add swm to include ping field of companion ping

### DIFF
--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -59,7 +59,7 @@ class SwmUtils(private val context: Context) {
         saveDiagnostic()
         val swmDiagnosticJSONarr = JSONArray()
         val rssi = app.swmMetaDb.dbSwmDiagnostic.concatRowsIgnoreNull
-        if (rssi.length > 0) {
+        if (rssi.isNotEmpty()) {
             val diagnosticJson = JSONObject()
             diagnosticJson.put("swm", rssi)
             swmDiagnosticJSONarr.put(diagnosticJson)

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingJsonUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingJsonUtils.java
@@ -30,7 +30,7 @@ public class ApiPingJsonUtils {
 
 	private RfcxGuardian app;
 
-	public String buildPingJson(boolean includeAllExtraFields, String[] includeExtraFields, int includeAssetBundleCount, boolean printJsonToLogs, String[] excludeFieldsFromLogs) throws JSONException {
+	public String buildPingJson(boolean includeAllExtraFields, String[] includeExtraFields, int includeAssetBundleCount, boolean printJsonToLogs, String[] excludeFieldsFromLogs, boolean shouldShorten) throws JSONException {
 
 		JSONObject jsonObj = new JSONObject();
 
@@ -144,7 +144,10 @@ public class ApiPingJsonUtils {
 			Log.d(logTag, (strLogs.length() <= limitLogsTo) ? strLogs : strLogs.substring(0, limitLogsTo) + "...");
 		}
 
-		return ApiPingExt.INSTANCE.shortenPingJson(jsonObj).toString();
+		if (shouldShorten) {
+			return ApiPingExt.INSTANCE.shortenPingJson(jsonObj).toString();
+		}
+		return jsonObj.toString();
 	}
 
 

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingUtils.java
@@ -50,7 +50,7 @@ public class ApiPingUtils {
 
 		try {
 
-			String pingJson = app.apiPingJsonUtils.buildPingJson(includeAllExtraFields, includeExtraFields, includeAssetBundleCount, true, new String[]{} );
+			String pingJson = app.apiPingJsonUtils.buildPingJson(includeAllExtraFields, includeExtraFields, includeAssetBundleCount, true, new String[]{}, true);
 
 			for (String apiProtocol : apiProtocols) {
 

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
@@ -24,7 +24,7 @@ public class CompanionSocketUtils {
 	}
 
 	private static final String[] includePingFields = new String[] {
-			"battery", "instructions", "prefs_full", "software", "library", "device", "companion"
+			"battery", "instructions", "prefs_full", "software", "library", "device", "companion", "swm"
 	};
 
 	private static final String[] excludeFromLogs = new String[] { "prefs" };
@@ -98,7 +98,7 @@ public class CompanionSocketUtils {
 
 	public void updatePingJson(boolean printJsonToLogs) {
 		try {
-			pingJson =  app.apiPingJsonUtils.buildPingJson(false, includePingFields, 0, printJsonToLogs, excludeFromLogs );
+			pingJson =  app.apiPingJsonUtils.buildPingJson(false, includePingFields, 0, printJsonToLogs, excludeFromLogs, false);
 		} catch (JSONException e) {
 			RfcxLog.logExc(logTag, e, "updatePingJson");
 		}


### PR DESCRIPTION
resolve [#431](https://github.com/rfcx/companion-android/issues/431)
- Add `swm` field to companion ping to make it is included when socket is connected