### PR TITLE
Fix queue management not working when Companion connected

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/device/telephony/DeviceMobilePhone.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/device/telephony/DeviceMobilePhone.java
@@ -65,7 +65,7 @@ public class DeviceMobilePhone {
 	}
 
 	@SuppressLint({"MissingPermission", "HardwareIds"})
-	private String getSimPhoneNumber() {
+	public String getSimPhoneNumber() {
 		setSimPhoneNumber(((TelephonyManager) this.context.getSystemService(Context.TELEPHONY_SERVICE)).getLine1Number());
 		return this.simPhoneNumber;
 	}

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/ConnectivityUtils.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/ConnectivityUtils.java
@@ -14,6 +14,7 @@ public class ConnectivityUtils {
 
     private Double downloadSpeedTest = -1.0;
     private Double uploadSpeedTest = -1.0;
+    private boolean isFailed = false;
 
     public Double getDownloadSpeedTest() {
         return downloadSpeedTest;
@@ -23,11 +24,17 @@ public class ConnectivityUtils {
         return uploadSpeedTest;
     }
 
+    public boolean getFailed() {
+        return isFailed;
+    }
+
     public void setDownloadSpeedTest(Context context, String role) {
         HttpGet httpGet = new HttpGet(context, role);
         try {
+            isFailed = false;
             downloadSpeedTest = httpGet.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
         } catch (IOException e) {
+            isFailed = true;
             RfcxLog.logExc(logTag, e);
         }
     }
@@ -35,13 +42,11 @@ public class ConnectivityUtils {
     public void setUploadSpeedTest(Context context, String role) {
         HttpPostMultipart httpPostMultipart = new HttpPostMultipart(context, role);
         try {
-            uploadSpeedTest = httpPostMultipart.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info"); // test url
-        } catch (IOException e) {
+            isFailed = false;
+            uploadSpeedTest = httpPostMultipart.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 1000000); // test url
+        } catch (IOException | NoSuchAlgorithmException | KeyManagementException e) {
+            isFailed = true;
             RfcxLog.logExc(logTag, e);
-        } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-        } catch (KeyManagementException e) {
-            e.printStackTrace();
         }
     }
 }

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/ConnectivityUtils.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/ConnectivityUtils.java
@@ -1,0 +1,47 @@
+package org.rfcx.guardian.utility.network;
+
+import android.content.Context;
+
+import org.rfcx.guardian.utility.rfcx.RfcxLog;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public class ConnectivityUtils {
+
+    private static final String logTag = RfcxLog.generateLogTag("Utils", "ConnectivityUtils");
+
+    private Double downloadSpeedTest = -1.0;
+    private Double uploadSpeedTest = -1.0;
+
+    public Double getDownloadSpeedTest() {
+        return downloadSpeedTest;
+    }
+
+    public Double getUploadSpeedTest() {
+        return uploadSpeedTest;
+    }
+
+    public void setDownloadSpeedTest(Context context, String role) {
+        HttpGet httpGet = new HttpGet(context, role);
+        try {
+            downloadSpeedTest = httpGet.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
+        } catch (IOException e) {
+            RfcxLog.logExc(logTag, e);
+        }
+    }
+
+    public void setUploadSpeedTest(Context context, String role) {
+        HttpPostMultipart httpPostMultipart = new HttpPostMultipart(context, role);
+        try {
+            uploadSpeedTest = httpPostMultipart.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info"); // test url
+        } catch (IOException e) {
+            RfcxLog.logExc(logTag, e);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        } catch (KeyManagementException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/DownloadSpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/DownloadSpeedTest.java
@@ -48,4 +48,20 @@ public class DownloadSpeedTest extends HttpGet {
         Log.e(logTag,"Download Failed (" + DateTimeUtils.milliSecondDurationAsReadableString((System.currentTimeMillis() - startTime)) + ") from " + fullUrl);
         return -1;
     }
+
+    private int writeFileForTest(InputStream inputStream, FileOutputStream fileOutputStream, String logTag) {
+        int downloadedContent = 0;
+        try {
+            byte[] buffer = new byte[8192];
+            int bufferLength = 0;
+            while ((bufferLength = inputStream.read(buffer)) != -1) {
+                downloadedContent += bufferLength;
+                fileOutputStream.write(buffer, 0, bufferLength);
+            }
+            return downloadedContent;
+        } catch (IOException e) {
+            RfcxLog.logExc(logTag, e);
+            return downloadedContent;
+        }
+    }
 }

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/DownloadSpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/DownloadSpeedTest.java
@@ -1,0 +1,51 @@
+package org.rfcx.guardian.utility.network;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.rfcx.guardian.utility.misc.DateTimeUtils;
+import org.rfcx.guardian.utility.rfcx.RfcxLog;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class DownloadSpeedTest extends HttpGet {
+
+    public DownloadSpeedTest(Context context, String appRole) {
+        super(context, appRole);
+        this.context = context;
+        this.logTag = RfcxLog.generateLogTag(appRole, "DownloadSpeedTest");
+    }
+
+    private final Context context;
+    private final String logTag;
+
+    public double getDownloadSpeedTest(String fullUrl) throws IOException {
+        long startTime = System.currentTimeMillis();
+        StringBuilder url = (new StringBuilder()).append(fullUrl);
+
+        Log.v(logTag,"Initializing request to "+url.toString());
+
+        String testPath = context.getFilesDir().getAbsolutePath() + "test_download.txt";
+        File file = new File(testPath);
+        if (file.exists()) {
+            file.delete();
+        }
+        InputStream inputStream = httpGetFileInputStream(url.toString());
+        FileOutputStream fileOutputStream = httpGetFileOutputStream(file.getAbsolutePath(), this.logTag);
+
+        if ((inputStream != null) && (fileOutputStream != null)) {
+            int downloadedContent = writeFileForTest(inputStream, fileOutputStream, this.logTag);
+            fileOutputStream.flush();
+            fileOutputStream.close();
+            long downloadTime = System.currentTimeMillis() - startTime;
+            double downloadSpeed = (downloadedContent * 1.0) / downloadTime;
+            Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(downloadTime) + ") from "+fullUrl);
+            return downloadSpeed;
+        }
+        Log.e(logTag,"Download Failed (" + DateTimeUtils.milliSecondDurationAsReadableString((System.currentTimeMillis() - startTime)) + ") from " + fullUrl);
+        return -1;
+    }
+}

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
@@ -261,7 +261,7 @@ public class HttpGet {
 		}
 	}
 
-	public static FileOutputStream httpGetFileOutputStream(String filePath, String logTag) {
+	protected static FileOutputStream httpGetFileOutputStream(String filePath, String logTag) {
 		FileUtils.delete(filePath);
 		try {
 			return new FileOutputStream(filePath);
@@ -271,7 +271,7 @@ public class HttpGet {
 		return null;
 	}
 	
-	public InputStream httpGetFileInputStream(String fullUrl) {
+	protected InputStream httpGetFileInputStream(String fullUrl) {
     	String inferredProtocol = fullUrl.substring(0, fullUrl.indexOf(":"));
     	try {
 			if (inferredProtocol.equals("https")) {

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
@@ -128,33 +128,6 @@ public class HttpGet {
 		}
 		return false;
 	}
-
-	public double getDownloadSpeedTest(String fullUrl) throws IOException {
-		long startTime = System.currentTimeMillis();
-		StringBuilder url = (new StringBuilder()).append(fullUrl);
-
-		Log.v(logTag,"Initializing request to "+url.toString());
-
-		String testPath = context.getFilesDir().getAbsolutePath() + "test_download.txt";
-		File file = new File(testPath);
-		if (file.exists()) {
-			file.delete();
-		}
-		InputStream inputStream = httpGetFileInputStream(url.toString());
-		FileOutputStream fileOutputStream = httpGetFileOutputStream(file.getAbsolutePath(), this.logTag);
-
-		if ((inputStream != null) && (fileOutputStream != null)) {
-			int downloadedContent = writeFileForTest(inputStream, fileOutputStream, this.logTag);
-			fileOutputStream.flush();
-			fileOutputStream.close();
-			long downloadTime = System.currentTimeMillis() - startTime;
-			double downloadSpeed = (downloadedContent * 1.0) / downloadTime;
-			Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(downloadTime) + ") from "+fullUrl);
-			return downloadSpeed;
-		}
-		Log.e(logTag,"Download Failed (" + DateTimeUtils.milliSecondDurationAsReadableString((System.currentTimeMillis() - startTime)) + ") from " + fullUrl);
-		return -1;
-	}
 	
 	public boolean getAsFile(String fullUrl, String outputFilePath) {
 		return getAsFile(fullUrl, (new ArrayList<String[]>()), outputFilePath);
@@ -275,22 +248,6 @@ public class HttpGet {
 			}
 		} catch (IOException e) {
 			RfcxLog.logExc(logTag, e);
-		}
-	}
-
-	public int writeFileForTest(InputStream inputStream, FileOutputStream fileOutputStream, String logTag) {
-		int downloadedContent = 0;
-		try {
-			byte[] buffer = new byte[8192];
-			int bufferLength = 0;
-			while ((bufferLength = inputStream.read(buffer)) != -1) {
-				downloadedContent += bufferLength;
-				fileOutputStream.write(buffer, 0, bufferLength);
-			}
-			return downloadedContent;
-		} catch (IOException e) {
-			RfcxLog.logExc(logTag, e);
-			return downloadedContent;
 		}
 	}
 	

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
@@ -128,6 +128,33 @@ public class HttpGet {
 		}
 		return false;
 	}
+
+	public double getDownloadSpeedTest(String fullUrl) throws IOException {
+		long startTime = System.currentTimeMillis();
+		StringBuilder url = (new StringBuilder()).append(fullUrl);
+
+		Log.v(logTag,"Initializing request to "+url.toString());
+
+		String testPath = context.getFilesDir().getAbsolutePath() + "test_download.txt";
+		File file = new File(testPath);
+		if (file.exists()) {
+			file.delete();
+		}
+		InputStream inputStream = httpGetFileInputStream(url.toString());
+		FileOutputStream fileOutputStream = httpGetFileOutputStream(file.getAbsolutePath(), this.logTag);
+
+		if ((inputStream != null) && (fileOutputStream != null)) {
+			int downloadedContent = writeFileForTest(inputStream, fileOutputStream, this.logTag);
+			fileOutputStream.flush();
+			fileOutputStream.close();
+			long downloadTime = System.currentTimeMillis() - startTime;
+			double downloadSpeed = (downloadedContent * 1.0) / downloadTime;
+			Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(downloadTime) + ") from "+fullUrl);
+			return downloadSpeed;
+		}
+		Log.e(logTag,"Download Failed (" + DateTimeUtils.milliSecondDurationAsReadableString((System.currentTimeMillis() - startTime)) + ") from " + fullUrl);
+		return -1;
+	}
 	
 	public boolean getAsFile(String fullUrl, String outputFilePath) {
 		return getAsFile(fullUrl, (new ArrayList<String[]>()), outputFilePath);
@@ -248,6 +275,22 @@ public class HttpGet {
 			}
 		} catch (IOException e) {
 			RfcxLog.logExc(logTag, e);
+		}
+	}
+
+	private int writeFileForTest(InputStream inputStream, FileOutputStream fileOutputStream, String logTag) {
+		int downloadedContent = 0;
+		try {
+			byte[] buffer = new byte[8192];
+			int bufferLength = 0;
+			while ((bufferLength = inputStream.read(buffer)) != -1) {
+				downloadedContent += bufferLength;
+				fileOutputStream.write(buffer, 0, bufferLength);
+			}
+			return downloadedContent;
+		} catch (IOException e) {
+			RfcxLog.logExc(logTag, e);
+			return downloadedContent;
 		}
 	}
 	

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpGet.java
@@ -278,7 +278,7 @@ public class HttpGet {
 		}
 	}
 
-	private int writeFileForTest(InputStream inputStream, FileOutputStream fileOutputStream, String logTag) {
+	public int writeFileForTest(InputStream inputStream, FileOutputStream fileOutputStream, String logTag) {
 		int downloadedContent = 0;
 		try {
 			byte[] buffer = new byte[8192];
@@ -303,8 +303,8 @@ public class HttpGet {
 			RfcxLog.logExc(logTag, e);
 		}
 	}
-	
-	private static FileOutputStream httpGetFileOutputStream(String filePath, String logTag) {
+
+	public static FileOutputStream httpGetFileOutputStream(String filePath, String logTag) {
 		FileUtils.delete(filePath);
 		try {
 			return new FileOutputStream(filePath);
@@ -314,7 +314,7 @@ public class HttpGet {
 		return null;
 	}
 	
-	private InputStream httpGetFileInputStream(String fullUrl) {
+	public InputStream httpGetFileInputStream(String fullUrl) {
     	String inferredProtocol = fullUrl.substring(0, fullUrl.indexOf(":"));
     	try {
 			if (inferredProtocol.equals("https")) {

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
@@ -92,7 +92,7 @@ public class HttpPostMultipart {
 		return rtrnStr;
 	}
 
-	public double getUploadSpeedTest(String fullUrl) throws IOException, NoSuchAlgorithmException, KeyManagementException {
+	public double getUploadSpeedTest(String fullUrl, int size) throws IOException, NoSuchAlgorithmException, KeyManagementException {
 
 		String testPath = context.getFilesDir().getAbsolutePath() + "test_upload.txt";
 		File file = new File(testPath);
@@ -100,7 +100,7 @@ public class HttpPostMultipart {
 			file.delete();
 		}
 		RandomAccessFile rf = new RandomAccessFile(file, "rw");
-		rf.setLength(1000000); // 1 Mb
+		rf.setLength(size);
 
 		MultipartEntity requestEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
 		requestEntity.addPart("file", new FileBody(file));
@@ -113,7 +113,7 @@ public class HttpPostMultipart {
 			return -1.0;
 		}
 		long uploadTime = System.currentTimeMillis() - startTime;
-		double uploadSpeed = (1000000.0) / uploadTime;
+		double uploadSpeed = (size * 1.0) / uploadTime;
 		Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(uploadTime) +") from "+fullUrl);
 		return uploadSpeed;
 	}

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
@@ -87,16 +87,16 @@ public class HttpPostMultipart {
 		
 		long startTime = System.currentTimeMillis();
 		Log.v(logTag,"Sending "+FileUtils.bytesAsReadableString(requestEntity.getContentLength())+" to "+fullUrl);
-		String rtrnStr = executeMultipartPost(fullUrl, requestEntity, false);
+		String rtrnStr = executeMultipartPost(fullUrl, requestEntity);
 		Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(System.currentTimeMillis()-startTime ) +") from "+fullUrl);
 		return rtrnStr;
 	}
     
-	public String executeMultipartPost(String fullUrl, MultipartEntity requestEntity, boolean ignoreResult) throws IOException, KeyManagementException, NoSuchAlgorithmException {
+	public String executeMultipartPost(String fullUrl, MultipartEntity requestEntity) throws IOException, KeyManagementException, NoSuchAlgorithmException {
 
 		String inferredProtocol = fullUrl.substring(0, fullUrl.indexOf(":"));
 		if (inferredProtocol.equals("http")) {
-			return sendInsecurePostRequest((new URL(fullUrl)), requestEntity, ignoreResult);
+			return sendInsecurePostRequest((new URL(fullUrl)), requestEntity);
 		} else if (inferredProtocol.equals("https")) {
 			return sendSecurePostRequest((new URL(fullUrl)), requestEntity);
 		} else {
@@ -105,7 +105,7 @@ public class HttpPostMultipart {
 		}
 	}
 	
-	private String sendInsecurePostRequest(URL url, MultipartEntity entity, boolean ignoreResult) throws IOException {
+	private String sendInsecurePostRequest(URL url, MultipartEntity entity) throws IOException {
 		HttpURLConnection conn;
 		conn = (HttpURLConnection) url.openConnection();
 		conn.setReadTimeout(requestReadTimeout);
@@ -124,9 +124,6 @@ public class HttpPostMultipart {
 		outputStream.close();
 		conn.connect();
 		if (conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
-			if (ignoreResult) {
-				return "";
-			}
 			Log.v(logTag, "Downloading "+ FileUtils.bytesAsReadableString(conn.getContentLength()) +" from "+url.toString());
 			return readResponseStream("gzip".equalsIgnoreCase(conn.getContentEncoding()) ? (new GZIPInputStream(conn.getInputStream())) : conn.getInputStream());
 		} else {

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
@@ -91,34 +91,8 @@ public class HttpPostMultipart {
 		Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(System.currentTimeMillis()-startTime ) +") from "+fullUrl);
 		return rtrnStr;
 	}
-
-	public double getUploadSpeedTest(String fullUrl, int size) throws IOException, NoSuchAlgorithmException, KeyManagementException {
-
-		String testPath = context.getFilesDir().getAbsolutePath() + "test_upload.txt";
-		File file = new File(testPath);
-		if (file.exists()) {
-			file.delete();
-		}
-		RandomAccessFile rf = new RandomAccessFile(file, "rw");
-		rf.setLength(size);
-
-		MultipartEntity requestEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
-		requestEntity.addPart("file", new FileBody(file));
-
-		long startTime = System.currentTimeMillis();
-		Log.v(logTag,"Sending "+FileUtils.bytesAsReadableString(requestEntity.getContentLength())+" to "+fullUrl);
-		String result = executeMultipartPost(fullUrl, requestEntity, true);
-
-		if (result == null) {
-			return -1.0;
-		}
-		long uploadTime = System.currentTimeMillis() - startTime;
-		double uploadSpeed = (size * 1.0) / uploadTime;
-		Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(uploadTime) +") from "+fullUrl);
-		return uploadSpeed;
-	}
     
-	private String executeMultipartPost(String fullUrl, MultipartEntity requestEntity, boolean ignoreResult) throws IOException, KeyManagementException, NoSuchAlgorithmException {
+	public String executeMultipartPost(String fullUrl, MultipartEntity requestEntity, boolean ignoreResult) throws IOException, KeyManagementException, NoSuchAlgorithmException {
 
 		String inferredProtocol = fullUrl.substring(0, fullUrl.indexOf(":"));
 		if (inferredProtocol.equals("http")) {

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/HttpPostMultipart.java
@@ -92,7 +92,7 @@ public class HttpPostMultipart {
 		return rtrnStr;
 	}
     
-	public String executeMultipartPost(String fullUrl, MultipartEntity requestEntity) throws IOException, KeyManagementException, NoSuchAlgorithmException {
+	protected String executeMultipartPost(String fullUrl, MultipartEntity requestEntity) throws IOException, KeyManagementException, NoSuchAlgorithmException {
 
 		String inferredProtocol = fullUrl.substring(0, fullUrl.indexOf(":"));
 		if (inferredProtocol.equals("http")) {

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 
-public class ConnectivityUtils {
+public class SpeedTest {
 
     private static final String logTag = RfcxLog.generateLogTag("Utils", "ConnectivityUtils");
 
@@ -29,10 +29,10 @@ public class ConnectivityUtils {
     }
 
     public void setDownloadSpeedTest(Context context, String role) {
-        HttpGet httpGet = new HttpGet(context, role);
+        DownloadSpeedTest downloadTest = new DownloadSpeedTest(context, role);
         try {
             isFailed = false;
-            downloadSpeedTest = httpGet.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
+            downloadSpeedTest = downloadTest.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
         } catch (IOException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);
@@ -40,10 +40,10 @@ public class ConnectivityUtils {
     }
 
     public void setUploadSpeedTest(Context context, String role) {
-        HttpPostMultipart httpPostMultipart = new HttpPostMultipart(context, role);
+        UploadSpeedTest uploadTest = new UploadSpeedTest(context, role);
         try {
             isFailed = false;
-            uploadSpeedTest = httpPostMultipart.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 1000000); // test url
+            uploadSpeedTest = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 1000000); // test url
         } catch (IOException | NoSuchAlgorithmException | KeyManagementException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
@@ -32,7 +32,7 @@ public class SpeedTest {
         DownloadSpeedTest downloadTest = new DownloadSpeedTest(context, role);
         try {
             isFailed = false;
-            downloadSpeedKbps = downloadTest.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
+            downloadSpeedKbps = downloadTest.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/100k.iso"); // test url
         } catch (IOException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);
@@ -43,7 +43,7 @@ public class SpeedTest {
         UploadSpeedTest uploadTest = new UploadSpeedTest(context, role);
         try {
             isFailed = false;
-            uploadSpeedKbps = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 1000000); // test url
+            uploadSpeedKbps = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 100000); // test url
         } catch (IOException | NoSuchAlgorithmException | KeyManagementException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
@@ -12,16 +12,16 @@ public class SpeedTest {
 
     private static final String logTag = RfcxLog.generateLogTag("Utils", "ConnectivityUtils");
 
-    private Double downloadSpeedTest = -1.0;
-    private Double uploadSpeedTest = -1.0;
+    private Double downloadSpeedKbps = -1.0;
+    private Double uploadSpeedKbps = -1.0;
     private boolean isFailed = false;
 
     public Double getDownloadSpeedTest() {
-        return downloadSpeedTest;
+        return downloadSpeedKbps;
     }
 
     public Double getUploadSpeedTest() {
-        return uploadSpeedTest;
+        return uploadSpeedKbps;
     }
 
     public boolean getFailed() {
@@ -32,7 +32,7 @@ public class SpeedTest {
         DownloadSpeedTest downloadTest = new DownloadSpeedTest(context, role);
         try {
             isFailed = false;
-            downloadSpeedTest = downloadTest.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
+            downloadSpeedKbps = downloadTest.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/1M.iso"); // test url
         } catch (IOException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);
@@ -43,7 +43,7 @@ public class SpeedTest {
         UploadSpeedTest uploadTest = new UploadSpeedTest(context, role);
         try {
             isFailed = false;
-            uploadSpeedTest = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 1000000); // test url
+            uploadSpeedKbps = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 1000000); // test url
         } catch (IOException | NoSuchAlgorithmException | KeyManagementException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/UploadSpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/UploadSpeedTest.java
@@ -1,0 +1,55 @@
+package org.rfcx.guardian.utility.network;
+
+import android.content.Context;
+import android.util.Log;
+
+import org.apache.http.entity.mime.HttpMultipartMode;
+import org.apache.http.entity.mime.MultipartEntity;
+import org.apache.http.entity.mime.content.FileBody;
+import org.rfcx.guardian.utility.misc.DateTimeUtils;
+import org.rfcx.guardian.utility.misc.FileUtils;
+import org.rfcx.guardian.utility.rfcx.RfcxLog;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public class UploadSpeedTest extends HttpPostMultipart {
+
+    public UploadSpeedTest(Context context, String appRole) {
+        super(context, appRole);
+        this.context = context;
+        this.logTag = RfcxLog.generateLogTag(appRole, "UploadSpeedTest");
+    }
+
+    private final Context context;
+    private final String logTag;
+
+    public double getUploadSpeedTest(String fullUrl, int size) throws IOException, NoSuchAlgorithmException, KeyManagementException {
+
+        String testPath = context.getFilesDir().getAbsolutePath() + "test_upload.txt";
+        File file = new File(testPath);
+        if (file.exists()) {
+            file.delete();
+        }
+        RandomAccessFile rf = new RandomAccessFile(file, "rw");
+        rf.setLength(size);
+
+        MultipartEntity requestEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
+        requestEntity.addPart("file", new FileBody(file));
+
+        long startTime = System.currentTimeMillis();
+        Log.v(logTag,"Sending "+ FileUtils.bytesAsReadableString(requestEntity.getContentLength())+" to "+fullUrl);
+        String result = executeMultipartPost(fullUrl, requestEntity, true);
+
+        if (result == null) {
+            return -1.0;
+        }
+        long uploadTime = System.currentTimeMillis() - startTime;
+        double uploadSpeed = (size * 1.0) / uploadTime;
+        Log.v(logTag,"Completed (" + DateTimeUtils.milliSecondDurationAsReadableString(uploadTime) +") from "+fullUrl);
+        return uploadSpeed;
+    }
+}

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/UploadSpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/UploadSpeedTest.java
@@ -42,7 +42,7 @@ public class UploadSpeedTest extends HttpPostMultipart {
 
         long startTime = System.currentTimeMillis();
         Log.v(logTag,"Sending "+ FileUtils.bytesAsReadableString(requestEntity.getContentLength())+" to "+fullUrl);
-        String result = executeMultipartPost(fullUrl, requestEntity, true);
+        String result = executeMultipartPost(fullUrl, requestEntity);
 
         if (result == null) {
             return -1.0;

--- a/role-admin/build.gradle
+++ b/role-admin/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "org.rfcx.guardian.admin"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 5
-        versionName "0.9.1"
+        versionCode 7
+        versionName "0.9.2"
         resConfigs "en"
         setProperty("archivesBaseName", "admin-$versionName")
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/RfcxGuardian.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/RfcxGuardian.java
@@ -56,6 +56,7 @@ import org.rfcx.guardian.utility.device.hardware.DeviceHardware_OrangePi_3G_IOT;
 import org.rfcx.guardian.utility.misc.DateTimeUtils;
 import org.rfcx.guardian.utility.device.DeviceConnectivity;
 import org.rfcx.guardian.utility.device.control.DeviceAirplaneMode;
+import org.rfcx.guardian.utility.network.ConnectivityUtils;
 import org.rfcx.guardian.utility.network.SSHServerUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxGuardianIdentity;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
@@ -143,6 +144,7 @@ public class RfcxGuardian extends Application {
 	public SbdUtils sbdUtils = null;
 	public SwmUtils swmUtils = null;
 
+	public ConnectivityUtils connectivityUtils = null;
 
 	// Receivers
 	private final BroadcastReceiver connectivityReceiver = new ConnectivityReceiver();
@@ -186,6 +188,7 @@ public class RfcxGuardian extends Application {
 		this.companionPingJsonUtils = new CompanionPingJsonUtils(this);
 		this.sbdUtils = new SbdUtils(this);
 		this.swmUtils = new SwmUtils(this);
+		this.connectivityUtils = new ConnectivityUtils();
 
 		DeviceI2CUtils.setSentinelLoggingVerbosity(this);
 		DeviceUtils.setSystemLoggingVerbosity(this);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/RfcxGuardian.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/RfcxGuardian.java
@@ -56,7 +56,7 @@ import org.rfcx.guardian.utility.device.hardware.DeviceHardware_OrangePi_3G_IOT;
 import org.rfcx.guardian.utility.misc.DateTimeUtils;
 import org.rfcx.guardian.utility.device.DeviceConnectivity;
 import org.rfcx.guardian.utility.device.control.DeviceAirplaneMode;
-import org.rfcx.guardian.utility.network.ConnectivityUtils;
+import org.rfcx.guardian.utility.network.SpeedTest;
 import org.rfcx.guardian.utility.network.SSHServerUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxGuardianIdentity;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
@@ -144,7 +144,7 @@ public class RfcxGuardian extends Application {
 	public SbdUtils sbdUtils = null;
 	public SwmUtils swmUtils = null;
 
-	public ConnectivityUtils connectivityUtils = null;
+	public SpeedTest speedTest = null;
 
 	// Receivers
 	private final BroadcastReceiver connectivityReceiver = new ConnectivityReceiver();
@@ -188,7 +188,7 @@ public class RfcxGuardian extends Application {
 		this.companionPingJsonUtils = new CompanionPingJsonUtils(this);
 		this.sbdUtils = new SbdUtils(this);
 		this.swmUtils = new SwmUtils(this);
-		this.connectivityUtils = new ConnectivityUtils();
+		this.speedTest = new SpeedTest();
 
 		DeviceI2CUtils.setSentinelLoggingVerbosity(this);
 		DeviceUtils.setSystemLoggingVerbosity(this);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -33,7 +33,7 @@ public class SwmMessageDb {
 	static final String C_LAST_ACCESSED_AT = "last_accessed_at";
 	private static final String[] ALL_COLUMNS = new String[] { C_CREATED_AT, C_TIMESTAMP, C_ADDRESS, C_BODY, C_GROUP_ID, C_MESSAGE_ID, C_SWM_MESSAGE_ID, C_LAST_ACCESSED_AT };
 
-	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { "0.9.1", "0.9.2", "0.9.3"}; // "0.6.43"
+	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { "0.9.1", "0.9.2" }; // "0.6.43"
 	private boolean DROP_TABLE_ON_UPGRADE = true;
 
 	private String createColumnString(String tableName) {

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -33,7 +33,7 @@ public class SwmMessageDb {
 	static final String C_LAST_ACCESSED_AT = "last_accessed_at";
 	private static final String[] ALL_COLUMNS = new String[] { C_CREATED_AT, C_TIMESTAMP, C_ADDRESS, C_BODY, C_GROUP_ID, C_MESSAGE_ID, C_SWM_MESSAGE_ID, C_LAST_ACCESSED_AT };
 
-	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { "0.9.1", "0.9.2" }; // "0.6.43"
+	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { "0.9.1", "0.9.2", "0.9.3"}; // "0.6.43"
 	private boolean DROP_TABLE_ON_UPGRADE = true;
 
 	private String createColumnString(String tableName) {

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmMessageDb.java
@@ -33,7 +33,7 @@ public class SwmMessageDb {
 	static final String C_LAST_ACCESSED_AT = "last_accessed_at";
 	private static final String[] ALL_COLUMNS = new String[] { C_CREATED_AT, C_TIMESTAMP, C_ADDRESS, C_BODY, C_GROUP_ID, C_MESSAGE_ID, C_SWM_MESSAGE_ID, C_LAST_ACCESSED_AT };
 
-	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { }; // "0.6.43"
+	static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[] { "0.9.1", "0.9.2" }; // "0.6.43"
 	private boolean DROP_TABLE_ON_UPGRADE = true;
 
 	private String createColumnString(String tableName) {

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -30,6 +30,8 @@ class SwmUtils(private val context: Context) {
     lateinit var power: SwmPower
     lateinit var api: SwmApi
 
+    private var swmId: String? = null
+
     fun setupSwmUtils() {
         power = SwmPower(context)
         api = SwmApi(SwmConnection(SwmUartShell()))
@@ -124,6 +126,12 @@ class SwmUtils(private val context: Context) {
                 null
             )
         }
+    }
+
+    fun getSwmId(): String? {
+        if (swmId != null) return swmId
+        swmId = api.getSwarmDeviceId()
+        return swmId
     }
 
     companion object {

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -129,7 +129,7 @@ class SwmUtils(private val context: Context) {
     }
 
     fun getSwmId(): String? {
-        if (swmId != null) return swmId
+        if (swmId != null || !::api.isInitialized) return swmId
         swmId = api.getSwarmDeviceId()
         return swmId
     }

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -109,22 +109,24 @@ class SwmUtils(private val context: Context) {
     }
 
     fun saveBackgroundSignal() {
-        val rtBackground = api.getRTBackground()
-        var rssiBackground: Int? = null
-        if (rtBackground != null) {
-            rssiBackground = rtBackground.rssi
-        }
+        if (!::api.isInitialized) {
+            val rtBackground = api.getRTBackground()
+            var rssiBackground: Int? = null
+            if (rtBackground != null) {
+                rssiBackground = rtBackground.rssi
+            }
 
-        if (rtBackground != null) {
-            app.swmMetaDb.dbSwmDiagnostic.insert(
-                rssiBackground,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-            )
+            if (rtBackground != null) {
+                app.swmMetaDb.dbSwmDiagnostic.insert(
+                    rssiBackground,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                )
+            }
         }
     }
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/SwmUtils.kt
@@ -56,7 +56,7 @@ class SwmUtils(private val context: Context) {
     }
 
     fun getMomentaryConcatDiagnosticValuesAsJsonArray(): JSONArray {
-        saveDiagnostic()
+        saveBackgroundSignal()
         val swmDiagnosticJSONarr = JSONArray()
         val rssi = app.swmMetaDb.dbSwmDiagnostic.concatRowsIgnoreNull
         if (rssi.isNotEmpty()) {
@@ -102,6 +102,26 @@ class SwmUtils(private val context: Context) {
                 time,
                 satId,
                 unsentMessageNumbers
+            )
+        }
+    }
+
+    fun saveBackgroundSignal() {
+        val rtBackground = api.getRTBackground()
+        var rssiBackground: Int? = null
+        if (rtBackground != null) {
+            rssiBackground = rtBackground.rssi
+        }
+
+        if (rtBackground != null) {
+            app.swmMetaDb.dbSwmDiagnostic.insert(
+                rssiBackground,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
             )
         }
     }

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
@@ -7,7 +7,7 @@ import java.util.*
 
 class SwmApi(private val connection: SwmConnection) {
 
-    enum class Command { TD, MT, SL, RT, DT, PO }
+    enum class Command { TD, MT, SL, RT, DT, PO, CS }
 
     private val datetimeCompactFormatter = SimpleDateFormat("yyyyMMddHHmmss").also { it.timeZone = TimeZone.getTimeZone("GMT") }
 
@@ -82,5 +82,14 @@ class SwmApi(private val connection: SwmConnection) {
                 datetimeCompactFormatter.parse(match.groupValues[1])
             } ?: return null
         return SwmDTResponse(datetime.time)
+    }
+
+    fun getSwarmDeviceId(): String? {
+        return connection.executeWithoutTimeout(Command.CS.name, "")
+            .firstOrNull()?.let {
+                val match = "DI=(0x[0-9]+)".toRegex().find(it) ?: return null
+                val (deviceId) = match.destructured
+                deviceId
+            } ?: return null
     }
 }

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
@@ -87,7 +87,7 @@ class SwmApi(private val connection: SwmConnection) {
     fun getSwarmDeviceId(): String? {
         return connection.executeWithoutTimeout(Command.CS.name, "")
             .firstOrNull()?.let {
-                val match = "DI=(0x[0-9]+)".toRegex().find(it) ?: return null
+                val match = "DI=(0x[a-z0-9]+)".toRegex().find(it) ?: return null
                 val (deviceId) = match.destructured
                 deviceId
             } ?: return null

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
@@ -87,7 +87,7 @@ class SwmApi(private val connection: SwmConnection) {
     fun getSwarmDeviceId(): String? {
         return connection.executeWithoutTimeout(Command.CS.name, "")
             .firstOrNull()?.let {
-                val match = "DI=(0x[a-z0-9]+)".toRegex().find(it) ?: return null
+                val match = "DI=0x([a-z0-9]+)".toRegex().find(it) ?: return null
                 val (deviceId) = match.destructured
                 deviceId
             } ?: return null

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/comms/swm/api/SwmApi.kt
@@ -89,7 +89,7 @@ class SwmApi(private val connection: SwmConnection) {
             .firstOrNull()?.let {
                 val match = "DI=0x([a-fA-F0-9]+)".toRegex().find(it) ?: return null
                 val (deviceId) = match.destructured
-                deviceId.toLowerCase(Locale.getDefault())
+                deviceId.lowercase()
             } ?: return null
     }
 }

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -95,7 +95,7 @@ public class CompanionPingJsonUtils {
 			simInfo.put("phone_number", phoneNumber);
 			companionJsonObj.put("sim_info", simInfo);
 
-			String swarmId = app.swmUtils.api.getSwarmDeviceId();
+			String swarmId = app.swmUtils.getSwmId();
 			JSONObject satInfo = new JSONObject();
 			simInfo.put("sat_id", swarmId);
 			companionJsonObj.put("sat_info", satInfo);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -9,7 +9,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.rfcx.guardian.admin.RfcxGuardian;
 import org.rfcx.guardian.admin.comms.sms.SmsUtils;
-import org.rfcx.guardian.admin.comms.swm.data.SwmRTBackgroundResponse;
 import org.rfcx.guardian.admin.device.i2c.DeviceI2CUtils;
 import org.rfcx.guardian.utility.misc.ArrayUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
@@ -102,9 +101,9 @@ public class CompanionPingJsonUtils {
 
 			JSONObject speedTest = new JSONObject();
 			speedTest.put("connection_available", app.deviceConnectivity.isConnected());
-			speedTest.put("is_failed", app.connectivityUtils.getFailed());
-			speedTest.put("download_speed", app.connectivityUtils.getDownloadSpeedTest());
-			speedTest.put("upload_speed", app.connectivityUtils.getUploadSpeedTest());
+			speedTest.put("is_failed", app.speedTest.getFailed());
+			speedTest.put("download_speed", app.speedTest.getDownloadSpeedTest());
+			speedTest.put("upload_speed", app.speedTest.getUploadSpeedTest());
 			companionJsonObj.put("speed_test", speedTest);
 
 			jsonObj.put("companion", companionJsonObj);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -97,7 +97,7 @@ public class CompanionPingJsonUtils {
 
 			String swarmId = app.swmUtils.getSwmId();
 			JSONObject satInfo = new JSONObject();
-			simInfo.put("sat_id", swarmId);
+			satInfo.put("sat_id", swarmId);
 			companionJsonObj.put("sat_info", satInfo);
 
 			jsonObj.put("companion", companionJsonObj);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -100,6 +100,11 @@ public class CompanionPingJsonUtils {
 			satInfo.put("sat_id", swarmId);
 			companionJsonObj.put("sat_info", satInfo);
 
+			JSONObject speedTest = new JSONObject();
+			speedTest.put("download_speed", app.connectivityUtils.getDownloadSpeedTest());
+			speedTest.put("upload_speed", app.connectivityUtils.getUploadSpeedTest());
+			companionJsonObj.put("speed_test", speedTest);
+
 			jsonObj.put("companion", companionJsonObj);
 		}
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -101,6 +101,8 @@ public class CompanionPingJsonUtils {
 			companionJsonObj.put("sat_info", satInfo);
 
 			JSONObject speedTest = new JSONObject();
+			speedTest.put("connection_available", app.deviceConnectivity.isConnected());
+			speedTest.put("is_failed", app.connectivityUtils.getFailed());
 			speedTest.put("download_speed", app.connectivityUtils.getDownloadSpeedTest());
 			speedTest.put("upload_speed", app.connectivityUtils.getUploadSpeedTest());
 			companionJsonObj.put("speed_test", speedTest);

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -84,8 +84,22 @@ public class CompanionPingJsonUtils {
 
 		if (includeAllExtraFields || ArrayUtils.doesStringArrayContainString(includeExtraFields, "companion")) {
 			JSONObject companionJsonObj = new JSONObject();
+
 			JSONObject i2cAccessibility = app.sentinelPowerUtils.getI2cAccessibilityAndFailMessage();
 			companionJsonObj.put("i2c", i2cAccessibility);
+
+			Boolean hasSim = app.deviceMobilePhone.hasSim();
+			String phoneNumber = app.deviceMobilePhone.getSimPhoneNumber();
+			JSONObject simInfo = new JSONObject();
+			simInfo.put("has_sim", hasSim);
+			simInfo.put("phone_number", phoneNumber);
+			companionJsonObj.put("sim_info", simInfo);
+
+			String swarmId = app.swmUtils.api.getSwarmDeviceId();
+			JSONObject satInfo = new JSONObject();
+			simInfo.put("sat_id", swarmId);
+			companionJsonObj.put("sat_info", satInfo);
+
 			jsonObj.put("companion", companionJsonObj);
 		}
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -84,6 +84,8 @@ public class CompanionPingJsonUtils {
 
 		if (includeAllExtraFields || ArrayUtils.doesStringArrayContainString(includeExtraFields, "companion")) {
 			JSONObject companionJsonObj = new JSONObject();
+			JSONObject i2cAccessibility = app.sentinelPowerUtils.getI2cAccessibilityAndFailMessage();
+			companionJsonObj.put("i2c", i2cAccessibility);
 			jsonObj.put("companion", companionJsonObj);
 		}
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -12,6 +12,7 @@ import org.rfcx.guardian.admin.comms.sms.SmsUtils;
 import org.rfcx.guardian.admin.device.i2c.DeviceI2CUtils;
 import org.rfcx.guardian.utility.misc.ArrayUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
+import org.rfcx.guardian.utility.rfcx.RfcxPrefs;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -94,10 +95,12 @@ public class CompanionPingJsonUtils {
 			simInfo.put("phone_number", phoneNumber);
 			companionJsonObj.put("sim_info", simInfo);
 
-			String swarmId = app.swmUtils.getSwmId();
-			JSONObject satInfo = new JSONObject();
-			satInfo.put("sat_id", swarmId);
-			companionJsonObj.put("sat_info", satInfo);
+			if (app.rfcxPrefs.getPrefAsString(RfcxPrefs.Pref.API_SATELLITE_PROTOCOL).equalsIgnoreCase("swm")) {
+				String swarmId = app.swmUtils.getSwmId();
+				JSONObject satInfo = new JSONObject();
+				satInfo.put("sat_id", swarmId);
+				companionJsonObj.put("sat_info", satInfo);
+			}
 
 			JSONObject speedTest = new JSONObject();
 			speedTest.put("connection_available", app.deviceConnectivity.isConnected());

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionSocketUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionSocketUtils.java
@@ -23,7 +23,7 @@ public class CompanionSocketUtils {
 	}
 
 	private static final String[] includePingFields = new String[] {
-			"network", "sentinel_power", "sentinel_sensor", "cpu", "storage"
+			"network", "sentinel_power", "sentinel_sensor", "cpu", "storage", "companion"
 	};
 
 	private static final String[] excludeFromLogs = new String[] { };

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
@@ -2,9 +2,7 @@ package org.rfcx.guardian.admin.contentprovider;
 
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
-import org.json.JSONObject;
 import org.rfcx.guardian.admin.comms.swm.SwmUtils;
-import org.rfcx.guardian.admin.comms.swm.data.SwmRTBackgroundResponse;
 import org.rfcx.guardian.admin.device.android.capture.LogcatCaptureService;
 import org.rfcx.guardian.admin.device.android.capture.ScreenShotCaptureService;
 import org.rfcx.guardian.admin.device.android.control.AirplaneModeToggleService;
@@ -20,7 +18,6 @@ import org.rfcx.guardian.utility.device.DeviceSmsUtils;
 import org.rfcx.guardian.utility.device.control.DeviceKeyEntry;
 import org.rfcx.guardian.utility.misc.DateTimeUtils;
 import org.rfcx.guardian.utility.misc.StringUtils;
-import org.rfcx.guardian.utility.network.ConnectivityUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxComm;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
 import org.rfcx.guardian.utility.rfcx.RfcxPrefs;
@@ -145,8 +142,8 @@ public class AdminContentProvider extends ContentProvider {
                 return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"test_sbd", isSuccessful, System.currentTimeMillis()});
 
             } else if (RfcxComm.uriMatch(uri, appRole, "control", "speed_test")) { logFuncVal = "control-speed_test";
-                app.connectivityUtils.setDownloadSpeedTest(getContext(), appRole);
-                app.connectivityUtils.setUploadSpeedTest(getContext(), appRole);
+                app.speedTest.setDownloadSpeedTest(getContext(), appRole);
+                app.speedTest.setUploadSpeedTest(getContext(), appRole);
                 return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"speed_test", null, System.currentTimeMillis()});
 
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
@@ -145,8 +145,8 @@ public class AdminContentProvider extends ContentProvider {
                 return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"test_sbd", isSuccessful, System.currentTimeMillis()});
 
             } else if (RfcxComm.uriMatch(uri, appRole, "control", "speed_test")) { logFuncVal = "control-speed_test";
-                app.connectivityUtils.setUploadSpeedTest(getContext(), appRole);
                 app.connectivityUtils.setDownloadSpeedTest(getContext(), appRole);
+                app.connectivityUtils.setUploadSpeedTest(getContext(), appRole);
                 return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"speed_test", null, System.currentTimeMillis()});
 
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
@@ -20,6 +20,7 @@ import org.rfcx.guardian.utility.device.DeviceSmsUtils;
 import org.rfcx.guardian.utility.device.control.DeviceKeyEntry;
 import org.rfcx.guardian.utility.misc.DateTimeUtils;
 import org.rfcx.guardian.utility.misc.StringUtils;
+import org.rfcx.guardian.utility.network.ConnectivityUtils;
 import org.rfcx.guardian.utility.rfcx.RfcxComm;
 import org.rfcx.guardian.utility.rfcx.RfcxLog;
 import org.rfcx.guardian.utility.rfcx.RfcxPrefs;
@@ -137,11 +138,16 @@ public class AdminContentProvider extends ContentProvider {
                 app.assetUtils.runFileSystemAssetCleanup();
                 return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"asset_cleanup", null, System.currentTimeMillis()});
 
-            } else if (RfcxComm.uriMatch(uri, appRole, "control", "test_sbd")) { logFuncVal = "control-test_sbd";
-                String randomString = "abcd"+"001"+StringUtils.randomAlphanumericString(113, false);
+            } else if (RfcxComm.uriMatch(uri, appRole, "control", "test_sbd")) {
+                logFuncVal = "control-test_sbd";
+                String randomString = "abcd" + "001" + StringUtils.randomAlphanumericString(113, false);
                 boolean isSuccessful = app.sbdUtils.sendSbdMessage(randomString);
                 return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"test_sbd", isSuccessful, System.currentTimeMillis()});
 
+            } else if (RfcxComm.uriMatch(uri, appRole, "control", "speed_test")) { logFuncVal = "control-speed_test";
+                app.connectivityUtils.setUploadSpeedTest(getContext(), appRole);
+                app.connectivityUtils.setDownloadSpeedTest(getContext(), appRole);
+                return RfcxComm.getProjectionCursor(appRole, "control", new Object[]{"speed_test", null, System.currentTimeMillis()});
 
 
             } else if (RfcxComm.uriMatch(uri, appRole, "keycode", "*")) { logFuncVal = "keycode-*";

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/contentprovider/AdminContentProvider.java
@@ -253,7 +253,9 @@ public class AdminContentProvider extends ContentProvider {
                         momentaryValueArr = app.deviceUtils.getMomentaryConcatSystemMetaValuesAsJsonArray("network");
 
                     } else if (pathSeg.equalsIgnoreCase("swm_diagnostic")) {
-                        momentaryValueArr = app.swmUtils.getMomentaryConcatDiagnosticValuesAsJsonArray();
+                        if (app.rfcxPrefs.getPrefAsString(RfcxPrefs.Pref.API_SATELLITE_PROTOCOL).equalsIgnoreCase("swm")) {
+                            momentaryValueArr = app.swmUtils.getMomentaryConcatDiagnosticValuesAsJsonArray();
+                        }
                     }
 
                 } catch (Exception e) {

--- a/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiCSTest.kt
+++ b/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiCSTest.kt
@@ -1,0 +1,25 @@
+package org.rfcx.guardian.admin.comms.swm
+
+import org.junit.Test
+import org.rfcx.guardian.admin.comms.swm.api.SwmApi
+import org.rfcx.guardian.admin.comms.swm.api.SwmConnection
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SwmApiCSTest {
+
+    @Test
+    fun canGetSwarmId() {
+        // Arrange
+        val shell = SwmMockShell(listOf("\$CS DI=0x000e57,DN=TILE*10"))
+        val api = SwmApi(SwmConnection(shell))
+
+        // Act
+        val deviceId = api.getSwarmDeviceId()
+
+        // Assert
+        assertNotNull(deviceId)
+        assertEquals("0x000e57", deviceId)
+    }
+
+}

--- a/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiCSTest.kt
+++ b/role-admin/src/test/java/org/rfcx/guardian/admin/comms/swm/SwmApiCSTest.kt
@@ -19,7 +19,7 @@ class SwmApiCSTest {
 
         // Assert
         assertNotNull(deviceId)
-        assertEquals("0x000e57", deviceId)
+        assertEquals("000e57", deviceId)
     }
 
 }

--- a/role-guardian/build.gradle
+++ b/role-guardian/build.gradle
@@ -13,8 +13,8 @@ android {
         applicationId "org.rfcx.guardian.guardian"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 8
-        versionName "0.9.2"
+        versionCode 9
+        versionName "0.9.3"
         resConfigs "en"
         setProperty("archivesBaseName", "guardian-$versionName")
         manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "rfcx"]

--- a/role-guardian/build.gradle
+++ b/role-guardian/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 9
-        versionName "0.9.3"
+        versionName "0.9.2"
         resConfigs "en"
         setProperty("archivesBaseName", "guardian-$versionName")
         manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "rfcx"]

--- a/role-guardian/src/main/res/values/strings.xml
+++ b/role-guardian/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
 	<string name="prefs_value_default_api_ntp_host">time.apple.com</string>
 	<string name="prefs_value_default_api_sms_address">+14154803657</string>
 
-	<string name="prefs_value_api_protocol_escalation_order">mqtt,rest,sms,sat</string>
+	<string name="prefs_value_api_protocol_escalation_order">mqtt,rest</string>
 
 	<string name="prefs_value_default_reboot_forced_daily_at">23:55:00</string>
 
@@ -121,7 +121,7 @@
 
 	<string name="prefs_value_default_api_satellite_protocol">off</string>
 
-	<string name="prefs_value_default_enable_file_socket">false</string>
+	<string name="prefs_value_default_enable_file_socket">true</string>
 
 	<string-array name="prefs_values_api_satellite_protocol">
 		<item>off</item>


### PR DESCRIPTION
- Separate getting background for Companion to isolate function to avoid time usage of ping creation as possible because ping sending is running parallel with swm service which sometimes will running the command at the same time
- Remove sms out of default guardian prefs
- Not trying sending swm data if prefs is not set
- Download/Upload to 100kb