### PR TITLE
Add local time to guardian ping

### DIFF
--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
@@ -50,6 +50,8 @@ public class CompanionSocketUtils {
 
 			companionObj.put("checkin", getLatestAllSentCheckInType());
 
+			companionObj.put("local_time", System.currentTimeMillis());
+			
 		} catch (JSONException e) {
 			RfcxLog.logExc(logTag, e);
 		}


### PR DESCRIPTION
resolve [452](https://github.com/rfcx/companion-android/issues/452)
- include local time in guardian ping for companion to show