### PR TITLE
Fix upload fail when speed test

### DIFF
--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
@@ -43,7 +43,7 @@ public class SpeedTest {
         UploadSpeedTest uploadTest = new UploadSpeedTest(context, role);
         try {
             isFailed = false;
-            uploadSpeedKbps = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 100000); // test url
+            uploadSpeedKbps = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 102400); // test url
         } catch (IOException | NoSuchAlgorithmException | KeyManagementException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/SpeedTest.java
@@ -15,6 +15,7 @@ public class SpeedTest {
     private Double downloadSpeedKbps = -1.0;
     private Double uploadSpeedKbps = -1.0;
     private boolean isFailed = false;
+    private boolean isTesting = false;
 
     public Double getDownloadSpeedTest() {
         return downloadSpeedKbps;
@@ -28,25 +29,33 @@ public class SpeedTest {
         return isFailed;
     }
 
+    public boolean getTestingState() {
+        return isTesting;
+    }
+
     public void setDownloadSpeedTest(Context context, String role) {
         DownloadSpeedTest downloadTest = new DownloadSpeedTest(context, role);
         try {
+            isTesting = true;
             isFailed = false;
             downloadSpeedKbps = downloadTest.getDownloadSpeedTest("http://ipv4.ikoula.testdebit.info/100k.iso"); // test url
         } catch (IOException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);
         }
+        isTesting = false;
     }
 
     public void setUploadSpeedTest(Context context, String role) {
         UploadSpeedTest uploadTest = new UploadSpeedTest(context, role);
         try {
+            isTesting = true;
             isFailed = false;
             uploadSpeedKbps = uploadTest.getUploadSpeedTest("http://ipv4.ikoula.testdebit.info", 102400); // test url
         } catch (IOException | NoSuchAlgorithmException | KeyManagementException e) {
             isFailed = true;
             RfcxLog.logExc(logTag, e);
         }
+        isTesting = false;
     }
 }

--- a/lib-core/src/main/java/org/rfcx/guardian/utility/network/UploadSpeedTest.java
+++ b/lib-core/src/main/java/org/rfcx/guardian/utility/network/UploadSpeedTest.java
@@ -34,18 +34,22 @@ public class UploadSpeedTest extends HttpPostMultipart {
         if (file.exists()) {
             file.delete();
         }
-        RandomAccessFile rf = new RandomAccessFile(file, "rw");
-        rf.setLength(size);
-
-        MultipartEntity requestEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
-        requestEntity.addPart("file", new FileBody(file));
-
         long startTime = System.currentTimeMillis();
-        Log.v(logTag,"Sending "+ FileUtils.bytesAsReadableString(requestEntity.getContentLength())+" to "+fullUrl);
-        String result = executeMultipartPost(fullUrl, requestEntity);
+        try {
+            RandomAccessFile rf = new RandomAccessFile(file, "rw");
+            rf.setLength(size);
 
-        if (result == null) {
-            return -1.0;
+            MultipartEntity requestEntity = new MultipartEntity(HttpMultipartMode.BROWSER_COMPATIBLE);
+            requestEntity.addPart("file", new FileBody(file));
+
+            Log.v(logTag,"Sending "+ FileUtils.bytesAsReadableString(requestEntity.getContentLength())+" to "+fullUrl);
+            String result = executeMultipartPost(fullUrl, requestEntity);
+
+            if (result == null) {
+                return -1.0;
+            }
+        } catch (IOException e) {
+            RfcxLog.logExc(logTag, e);
         }
         long uploadTime = System.currentTimeMillis() - startTime;
         double uploadSpeed = (size * 1.0) / uploadTime;

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionPingJsonUtils.java
@@ -105,6 +105,7 @@ public class CompanionPingJsonUtils {
 			JSONObject speedTest = new JSONObject();
 			speedTest.put("connection_available", app.deviceConnectivity.isConnected());
 			speedTest.put("is_failed", app.speedTest.getFailed());
+			speedTest.put("is_testing", app.speedTest.getTestingState());
 			speedTest.put("download_speed", app.speedTest.getDownloadSpeedTest());
 			speedTest.put("upload_speed", app.speedTest.getUploadSpeedTest());
 			companionJsonObj.put("speed_test", speedTest);


### PR DESCRIPTION
- add `is_testing` for companion to know what the state is
- this current endpoint somehow not working on upload when the file uploading finish the endpoint itself close the socket and make an error so the point of this fix is skip the error but use the time of how long it used to calculate the speed