### PR TITLE
Fix same detection in every segment payload

### DIFF
--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/checkin/ApiCheckInJsonUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/checkin/ApiCheckInJsonUtils.java
@@ -34,7 +34,7 @@ public class ApiCheckInJsonUtils {
         JSONObject jsonObj = app.metaJsonUtils.retrieveAndBundleMetaJson(null, app.rfcxPrefs.getPrefAsInt(RfcxPrefs.Pref.CHECKIN_META_SEND_BUNDLE_LIMIT), false);
 
         // bundle and add detections
-        jsonObj = app.audioDetectionJsonUtils.retrieveAndBundleDetectionJson(jsonObj, app.rfcxPrefs.getPrefAsInt(RfcxPrefs.Pref.CHECKIN_META_SEND_BUNDLE_LIMIT), false);
+        jsonObj = app.audioDetectionJsonUtils.retrieveAndBundleDetectionJson(jsonObj, app.rfcxPrefs.getPrefAsInt(RfcxPrefs.Pref.CHECKIN_META_SEND_BUNDLE_LIMIT), false, false);
 
         // Adding Audio JSON fields from checkin table
         JSONObject checkInJsonObj = new JSONObject(checkInJsonString);

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingJsonUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingJsonUtils.java
@@ -129,8 +129,13 @@ public class ApiPingJsonUtils {
         }
 
         if ((includeAllExtraFields && (includeAssetBundleCount > 0)) || ArrayUtils.doesStringArrayContainString(includeExtraFields, "detections")) {
-            jsonObj = app.audioDetectionJsonUtils.retrieveAndBundleDetectionJson(jsonObj, Math.max(includeAssetBundleCount, 1), false);
-            includePurgedAssetList = true;
+            if (app.rfcxPrefs.getPrefAsString(RfcxPrefs.Pref.API_SATELLITE_PROTOCOL).equalsIgnoreCase("swm")) {
+                jsonObj = app.audioDetectionJsonUtils.retrieveAndBundleDetectionJson(jsonObj, Math.max(includeAssetBundleCount, 1), false, true);
+                includePurgedAssetList = false;
+            } else {
+                jsonObj = app.audioDetectionJsonUtils.retrieveAndBundleDetectionJson(jsonObj, Math.max(includeAssetBundleCount, 1), false, false);
+                includePurgedAssetList = true;
+            }
         }
 
         if (includeAllExtraFields || ArrayUtils.doesStringArrayContainString(includeExtraFields, "checkins")) {

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingJsonUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/api/methods/ping/ApiPingJsonUtils.java
@@ -129,7 +129,7 @@ public class ApiPingJsonUtils {
         }
 
         if ((includeAllExtraFields && (includeAssetBundleCount > 0)) || ArrayUtils.doesStringArrayContainString(includeExtraFields, "detections")) {
-            if (app.rfcxPrefs.getPrefAsString(RfcxPrefs.Pref.API_SATELLITE_PROTOCOL).equalsIgnoreCase("swm")) {
+            if (app.rfcxPrefs.getPrefAsString(RfcxPrefs.Pref.API_PROTOCOL_ESCALATION_ORDER).equalsIgnoreCase("sat")) {
                 jsonObj = app.audioDetectionJsonUtils.retrieveAndBundleDetectionJson(jsonObj, Math.max(includeAssetBundleCount, 1), false, true);
                 includePurgedAssetList = false;
             } else {

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/detections/AudioDetectionDb.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/detections/AudioDetectionDb.java
@@ -149,6 +149,10 @@ public class AudioDetectionDb {
             return this.dbUtils.getRowsWithNumericColumnHigherOrLowerThan(TABLE, ALL_COLUMNS, C_LAST_ACCESSED_AT, notAccessedSince, true, C_CREATED_AT, maxRows);
         }
 
+        public List<String[]> getLatestRowsNotAccessedWithLimit(int maxRows) {
+            return this.dbUtils.getRows(TABLE, ALL_COLUMNS, C_LAST_ACCESSED_AT + " = ?", new String[]{"0"}, C_CREATED_AT, 0, maxRows);
+        }
+
         public List<String[]> getLatestRowsWithLimit(int maxRows) {
             return this.dbUtils.getRows(TABLE, ALL_COLUMNS, null, null, C_CREATED_AT, 0, maxRows);
         }

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/detections/AudioDetectionJsonUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/detections/AudioDetectionJsonUtils.java
@@ -23,7 +23,7 @@ public class AudioDetectionJsonUtils {
 
     }
 
-    public JSONObject retrieveAndBundleDetectionJson(JSONObject insertDetectionsInto, int maxDtcnRowsToBundle, boolean overrideFilterByLastAccessedAt) throws JSONException {
+    public JSONObject retrieveAndBundleDetectionJson(JSONObject insertDetectionsInto, int maxDtcnRowsToBundle, boolean overrideFilterByLastAccessedAt, boolean forSatellite) throws JSONException {
 
         if (insertDetectionsInto == null) {
             insertDetectionsInto = new JSONObject();
@@ -31,9 +31,13 @@ public class AudioDetectionJsonUtils {
 
         JSONArray dtcnIds = new JSONArray();
         ArrayList<String> dtcnList = new ArrayList<>();
-
-        List<String[]> dtcnRows = (overrideFilterByLastAccessedAt) ? app.audioDetectionDb.dbFiltered.getLatestRowsWithLimit(maxDtcnRowsToBundle) :
-                app.audioDetectionDb.dbFiltered.getLatestRowsNotAccessedSinceWithLimit((System.currentTimeMillis() - app.apiMqttUtils.getSetCheckInPublishTimeOutLength()), maxDtcnRowsToBundle);
+        List<String[]> dtcnRows;
+        if (forSatellite) {
+            dtcnRows = app.audioDetectionDb.dbFiltered.getLatestRowsNotAccessedWithLimit(maxDtcnRowsToBundle);
+        } else {
+            dtcnRows = (overrideFilterByLastAccessedAt) ? app.audioDetectionDb.dbFiltered.getLatestRowsWithLimit(maxDtcnRowsToBundle) :
+                    app.audioDetectionDb.dbFiltered.getLatestRowsNotAccessedSinceWithLimit((System.currentTimeMillis() - app.apiMqttUtils.getSetCheckInPublishTimeOutLength()), maxDtcnRowsToBundle);
+        }
 
         for (String[] dtcnRow : dtcnRows) {
 

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/detections/AudioDetectionJsonUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/detections/AudioDetectionJsonUtils.java
@@ -46,7 +46,11 @@ public class AudioDetectionJsonUtils {
             dtcnList.add(TextUtils.join("*", new String[]{dtcnRow[1], dtcnRow[3] + "-v" + dtcnRow[4], dtcnRow[7], "" + Math.round(Double.parseDouble(dtcnRow[8]) * 1000), dtcnRow[10]}));
 
             // mark this row as accessed in the database
-            app.audioDetectionDb.dbFiltered.updateLastAccessedAtByCreatedAt(dtcnRow[0]);
+            if (forSatellite) {
+                app.audioDetectionDb.dbFiltered.deleteSingleRow(dtcnRow[1], dtcnRow[6]);
+            } else {
+                app.audioDetectionDb.dbFiltered.updateLastAccessedAtByCreatedAt(dtcnRow[0]);
+            }
 
             // if the bundle already contains max number of snapshots, stop here
             if (dtcnIds.length() >= maxDtcnRowsToBundle) {


### PR DESCRIPTION
Resolve #173 
- for swarm Guardian, it will get only detection that not accessed yet
- for swarm Guardian, it will delete detections row not update accessed timestamp