### PR TITLE
Properly close Looper and Thread

### DIFF
--- a/role-admin/build.gradle
+++ b/role-admin/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 16
-        versionName "1.1.2"
+        versionName "1.1.3"
         resConfigs "en"
         setProperty("archivesBaseName", "admin-$versionName")
 

--- a/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionSocketUtils.java
+++ b/role-admin/src/main/java/org/rfcx/guardian/admin/companion/CompanionSocketUtils.java
@@ -67,6 +67,11 @@ public class CompanionSocketUtils {
             try {
                 socketUtils.serverSetup();
                 while (true) {
+                    if (socketUtils.serverThread.isInterrupted()) {
+                        Log.d(logTag, "interrupted");
+                        Looper.myLooper().quit();
+                        return;
+                    }
                     InputStream socketInput = socketUtils.socketSetup();
                     if (socketInput != null) {
                         String jsonStr = socketUtils.streamSetup(socketInput);
@@ -76,7 +81,8 @@ public class CompanionSocketUtils {
                     }
                 }
             } catch (IOException | NullPointerException e) {
-                    RfcxLog.logExc(logTag, e);
+                RfcxLog.logExc(logTag, e);
+                Looper.myLooper().quit();
             }
             Looper.loop();
         });

--- a/role-classify/build.gradle
+++ b/role-classify/build.gradle
@@ -21,7 +21,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 9
-        versionName "1.1.2"
+        versionName "1.1.3"
         resConfigs "en"
         setProperty("archivesBaseName", "classify-$versionName")
 

--- a/role-guardian/build.gradle
+++ b/role-guardian/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 17
-        versionName "1.1.2"
+        versionName "1.1.3"
         resConfigs "en"
         setProperty("archivesBaseName", "guardian-$versionName")
         manifestPlaceholders = [auth0Domain: "@string/com_auth0_domain", auth0Scheme: "rfcx"]

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/library/AssetLibraryDb.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/asset/library/AssetLibraryDb.java
@@ -25,7 +25,7 @@ public class AssetLibraryDb {
     static final String C_META_NUMERIC_2 = "meta_numeric_2";
     static final String C_ATTEMPTS = "attempts";
     static final String C_LAST_ACCESSED_AT = "last_accessed_at";
-    static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[]{ "1.1.1" }; // "0.6.43"
+    static final String[] DROP_TABLES_ON_UPGRADE_TO_THESE_VERSIONS = new String[]{ "1.1.3" }; // "0.6.43"
     private static final String[] ALL_COLUMNS = new String[]{C_CREATED_AT, C_ASSET_ID, C_ASSET_TYPE, C_FORMAT, C_DIGEST, C_FILEPATH, C_FILESIZE, C_META_TEXT, C_META_NUMERIC_1, C_META_NUMERIC_2, C_ATTEMPTS, C_LAST_ACCESSED_AT};
     public final DbAudio dbAudio;
     public final DbClassifier dbClassifier;

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/audio/cast/AudioCastUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/audio/cast/AudioCastUtils.java
@@ -66,7 +66,7 @@ public class AudioCastUtils {
             Looper.prepare();
             try {
                 socketUtils.serverSetup();
-                while (true) {
+                while (!socketUtils.serverThread.isInterrupted()) {
                     InputStream socketInput = socketUtils.socketSetup();
                     if (socketInput != null) {
                         String jsonStr = socketUtils.streamSetup(socketInput);

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/audio/cast/AudioCastUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/audio/cast/AudioCastUtils.java
@@ -66,7 +66,12 @@ public class AudioCastUtils {
             Looper.prepare();
             try {
                 socketUtils.serverSetup();
-                while (!socketUtils.serverThread.isInterrupted()) {
+                while (true) {
+                    if (socketUtils.serverThread.isInterrupted()) {
+                        Log.d(logTag, "interrupted");
+                        Looper.myLooper().quit();
+                        return;
+                    }
                     InputStream socketInput = socketUtils.socketSetup();
                     if (socketInput != null) {
                         String jsonStr = socketUtils.streamSetup(socketInput);
@@ -77,6 +82,7 @@ public class AudioCastUtils {
                 }
             } catch (IOException | NullPointerException e) {
                     RfcxLog.logExc(logTag, e);
+                    Looper.myLooper().quit();
             }
             Looper.loop();
         });

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
@@ -133,6 +133,11 @@ public class CompanionSocketUtils {
             try {
                 socketUtils.serverSetup();
                 while (true) {
+                    if (socketUtils.serverThread.isInterrupted()) {
+                        Log.d(logTag, "interrupted");
+                        Looper.myLooper().quit();
+                        return;
+                    }
                     InputStream socketInput = socketUtils.socketSetup();
                     if (socketInput != null) {
                         String jsonStr = socketUtils.streamSetup(socketInput);
@@ -143,6 +148,7 @@ public class CompanionSocketUtils {
                 }
             } catch (IOException | NullPointerException e ) {
                 RfcxLog.logExc(logTag, e);
+                Looper.myLooper().quit();
             }
             Looper.loop();
         });

--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/file/FileSocketUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/file/FileSocketUtils.java
@@ -87,6 +87,11 @@ public class FileSocketUtils {
             try {
                 socketUtils.serverSetup();
                 while (true) {
+                    if (socketUtils.serverThread.isInterrupted()) {
+                        Log.d(logTag, "interrupted");
+                        Looper.myLooper().quit();
+                        return;
+                    }
                     InputStream socketInput = socketUtils.socketSetup();
                     if (socketInput != null) {
                         InputStream fileInput = socketUtils.streamFileSetup(socketInput);
@@ -218,7 +223,8 @@ public class FileSocketUtils {
                     }
                 }
             } catch (IOException | JSONException | NullPointerException e) {
-                    RfcxLog.logExc(logTag, e);
+                RfcxLog.logExc(logTag, e);
+                Looper.myLooper().quit();
             }
             Looper.loop();
         });


### PR DESCRIPTION
An issue we have now is that the guardian software restart itself after running 50-70 minutes and a cause is that threads that we created for all sockets, they created Looper and not closed it then GC that running and see many thread and Looper still in a RAM decided to close their process