### PR TITLE
Add token to ping

### DIFF
--- a/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
+++ b/role-guardian/src/main/java/org/rfcx/guardian/guardian/companion/CompanionSocketUtils.java
@@ -40,6 +40,7 @@ public class CompanionSocketUtils {
             JSONObject guardianObj = new JSONObject();
             guardianObj.put("guid", app.rfcxGuardianIdentity.getGuid());
             guardianObj.put("name", app.rfcxGuardianIdentity.getName());
+            guardianObj.put("token", app.rfcxGuardianIdentity.getAuthToken());
 
             companionObj.put("guardian", guardianObj);
 


### PR DESCRIPTION
Resolve #[Send Guardian vital to Core after deployed](https://github.com/rfcx/companion-android/issues/624)
- Add token in Companion ping for authentication